### PR TITLE
objects do not spawn instantly

### DIFF
--- a/client/weed.lua
+++ b/client/weed.lua
@@ -194,7 +194,7 @@ RegisterNetEvent('ps-drugprocessing:client:rollJoint', function()
 end)
 
 CreateThread(function()
-	local weedZone = CircleZone:Create(Config.CircleZones.WeedField.coords, 50.0, {
+	local weedZone = CircleZone:Create(Config.CircleZones.WeedField.coords, 10.0, {
 		name = "ps-weedzone",
 		debugPoly = false
 	})


### PR DESCRIPTION
solves the respawning of props without having to move too far from the area.
each client set to 50.0 should be changed to 10.0 to fix the problem